### PR TITLE
Fix/unlinked albums

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "deploy": "webpack -p & node-sass ./scss/ -o ../priv/static/css/",
-    "watch": "webpack --debug --progress --watch --colors",
+    "watch": "webpack --debug --watch --colors",
     "sass": "node-sass ./scss/ -o ../priv/static/css/",
     "watch:sass": "node-sass ./scss/ -o ../priv/static/css/ --watch --progress --inline"
   },

--- a/lib/treelib/photo_manager/photo_manager.ex
+++ b/lib/treelib/photo_manager/photo_manager.ex
@@ -131,6 +131,9 @@ defmodule Treelib.PhotoManager do
 
   """
   def get_album!(id), do: Repo.get!(PhotoAlbum, id)
+  def get_album(id), do: Repo.get(PhotoAlbum, id)
+
+  def get_album_by_name(name), do: Repo.get_by(PhotoAlbum, name: name)
 
   @doc """
   Creates a album.

--- a/lib/treelib/photo_manager/photo_updater.ex
+++ b/lib/treelib/photo_manager/photo_updater.ex
@@ -50,9 +50,7 @@ defmodule Treelib.PhotoManager.PhotoUpdater do
   def process_deletes pas, pss do
     delete_album_ids = PhotoUpdater.album_ids_to_delete(pas, pss)
 
-
-    # Note: No longer delete albums
-    # PhotoManager.delete_albums(delete_album_ids)
+    PhotoManager.delete_albums(delete_album_ids)
 
     PhotoManager.delete_photos_in_albums(delete_album_ids)
   end

--- a/lib/treelib/tasks/missing_albums.ex
+++ b/lib/treelib/tasks/missing_albums.ex
@@ -1,0 +1,34 @@
+defmodule Treelib.Tasks.MissingAlbums do
+  alias Treelib.Taxonomy.SpeciesManager
+  alias Treelib.PhotoManager
+  alias Treelib.Repo
+
+  def process do
+    IO.puts("[MA]: Starting")
+
+    SpeciesManager.all
+    |> SpeciesManager.with_genus
+    |> Enum.each(fn s ->
+      PhotoManager.get_album(s.album_id)
+      |> case do
+        nil -> find_and_link(s)
+        pa -> IO.puts("Album #{pa.id} found.")
+      end
+    end)
+
+    IO.puts("[MA]: Done")
+  end
+
+  def find_and_link(species) do
+    name = "#{species.genus.name} #{species.name}"
+
+    IO.puts("[MA]: Searching: #{name}")
+    PhotoManager.get_album_by_name(name)
+    |> case do
+      nil -> IO.puts("--> Not found")
+      pa -> IO.puts("--> Found an album with name #{name}")
+        SpeciesManager.update_species(species, %{ album_id: pa.id })
+    end
+  end
+
+end

--- a/test/treelib/photo_manager/photo_updater_test.exs
+++ b/test/treelib/photo_manager/photo_updater_test.exs
@@ -89,7 +89,6 @@ defmodule Treelib.PhotoManager.PhotoUpdaterTest do
   end
 
   describe "process_deletes" do
-    @tag :skip
     test "deletes albums that are in the db, but not on flickr", %{photo_albums: photo_albums, photosets: photosets}  do
       deleted_album = Treelib.Repo.get_by!(PhotoAlbum, photoset_id: 123456)
 


### PR DESCRIPTION
Flickr sometimes changes all the album ids and then all of a sudden none of the photos are linked on Treelib.

I wrote a script that links any albums that have the same name. 
